### PR TITLE
Fixed readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ schinquirer.prompt(
     {
         name: {
             type: "string",
-            pattern: "\d-\d"
+            pattern: "\\d-\\d"
         },
         car: {
             type: "string",
@@ -35,7 +35,7 @@ schinquirer.prompt(
         }
     
     },
-    function(answers) {
+    function(err, answers) {
         console.log(answers.name, "drives", answers.car);
     }
 );


### PR DESCRIPTION
The pattern was "d-d" instead of \d-\d. Also the callback function has the answers in the second argument as opposed to the first